### PR TITLE
Make pacemaker remote optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ Deploys corosync/pacemaker
 - `pacemaker_corosync_group`: Ansible group name for corosync cluster (default: false, *mandatory*)
 - `pacemaker_remote_group`: Ansible group name for pacemaker-remote cluster (default: false, *mandatory*)
 - `pacemaker_corosync_ring_interface`: Interface to use for ring0 communications (default: false, *mandatory*)
+- `pacemaker_remote_ring_interface`: Interface to use for ring0 communications on remote hosts (default: pacemaker_corosync_ring_interface)
 - `pacemaker_corosync_fqdn`: Whether use inventory_hostname or ansible_fqdn as node name for corosync (default: false)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 pacemaker_corosync_fqdn: false
 pacemaker_corosync_group: false
+pacemaker_remote_group: false
 pacemaker_corosync_ring_interface: false
+pacemaker_remote_ring_interface: "{{ pacemaker_corosync_ring_interface }}"
 pacemaker_corosync_use_syslog: true
 pacemaker_corosync_use_logfile: false

--- a/tasks/pacemaker.yml
+++ b/tasks/pacemaker.yml
@@ -26,7 +26,9 @@
     state: present
   with_items:
     - pacemaker-remote
-  when: "inventory_hostname in groups[pacemaker_remote_group]"
+  when:
+    - pacemaker_remote_group is defined and pacemaker_remote_group in groups
+    - "inventory_hostname in groups[pacemaker_remote_group]"
 
 - name: Install haveged
   package:

--- a/templates/corosync.conf.j2
+++ b/templates/corosync.conf.j2
@@ -1,8 +1,8 @@
-{%  if inventory_hostname in groups[pacemaker_corosync_group] %}
-{%    set _pacemaker_corosync_bind_addr = hostvars[inventory_hostname]['ansible_eth1' | replace('-', '_')].ipv4.address %}
-{% else %}
-{%    set _pacemaker_corosync_bind_addr = hostvars[inventory_hostname]['ansible_' + pacemaker_corosync_ring_interface | replace('-', '_')].ipv4.address %}
-{%  endif %}
+{% if inventory_hostname in groups[pacemaker_corosync_group] %}
+{%   set _pacemaker_corosync_bind_addr = hostvars[inventory_hostname]['ansible_' + pacemaker_corosync_ring_interface | replace('-', '_')].ipv4.address %}
+{% elif  pacemaker_remote_group in groups and inventory_hostname in groups[pacemaker_remote_group] %}
+{%   set _pacemaker_corosync_bind_addr = hostvars[inventory_hostname]['ansible_' + pacemaker_remote_ring_interface | replace('-', '_')].ipv4.address %}
+{% endif %}
 
 totem {
   version: 2
@@ -34,14 +34,14 @@ quorum {
 {% if pacemaker_enable_nodelist|default(true) %}
 nodelist {
 
-{% for node in groups[pacemaker_remote_group]|sort + groups[pacemaker_corosync_group]|sort %}
+{% for node in (groups[pacemaker_remote_group] | default([]) + groups[pacemaker_corosync_group]) | sort %}
 {%  if node in groups[pacemaker_corosync_group] %}
-{%    set _tmp_pacemaker_corosync_ring_interface = 'eth1' %}
-{% else %}
-{%    set _tmp_pacemaker_corosync_ring_interface = pacemaker_corosync_ring_interface %}
+{%    set _pacemaker_corosync_ring_interface = pacemaker_corosync_ring_interface %}
+{% elif pacemaker_remote_group in groups and inventory_hostname in groups[pacemaker_remote_group] %}
+{%    set _pacemaker_corosync_ring_interface = pacemaker_remote_ring_interface %}
 {%  endif %}
   node {
-    ring0_addr: {{ hostvars[node]['ansible_' + _tmp_pacemaker_corosync_ring_interface | replace('-', '_')].ipv4.address }}
+    ring0_addr: {{ hostvars[node]['ansible_' + _pacemaker_corosync_ring_interface | replace('-', '_')].ipv4.address }}
     name: {{ pacemaker_corosync_fqdn | bool | ternary(hostvars[node].ansible_fqdn, node) }}
     nodeid: {{ loop.index }}
   }


### PR DESCRIPTION
We added extra checks that pacemaker-remote group is defined.

Also this adds extra variable pacemaker_remote_ring_interface that is
used to determine IP address on the pacemaker remote hosts